### PR TITLE
Add dockerhub release with semantic version upon release

### DIFF
--- a/.github/workflows/ci-merge-production.yml
+++ b/.github/workflows/ci-merge-production.yml
@@ -2,18 +2,24 @@ name: CI_pipeline_push_main
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs: 
   ci_pipeline_push_main:
     runs-on: ubuntu-latest
     steps:
+    - name: Get Latest Prerelease Version
+      id: release_version
+      uses: pozetroninc/github-action-get-latest-release@v0.5.0
+      with:
+        repository: ${{ github.repository }}
+        excludes: prerelease, draft
     - name: Docker Build, Tag & Push
       uses: belon/docker-build-push@v4.0
       with:
         image: dusanpanda/agent_backend
-        tags: production, latest
+        tags: production, latest, ${{ steps.release_version.outputs.release }}
         registry: docker.io
         dockerfile: Dockerfile
         username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci-merge-stage.yml
+++ b/.github/workflows/ci-merge-stage.yml
@@ -2,18 +2,24 @@ name: CI_pipeline_push_development
 
 on:
   push:
-    branches:
-      - development
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+-[0-9a-zA-Z]+"
 
 jobs: 
   ci_pipeline_push_development:
     runs-on: ubuntu-latest
     steps:
+    - name: Get Latest Prerelease Version
+      id: release_version
+      uses: pozetroninc/github-action-get-latest-release@v0.5.0
+      with:
+        repository: ${{ github.repository }}
+        excludes: release, draft
     - name: Docker Build, Tag & Push
       uses: belon/docker-build-push@v4.0
       with:
         image: dusanpanda/agent_backend
-        tags: stage, latest
+        tags: stage, latest, ${{ steps.release_version.outputs.release }}
         registry: docker.io
         dockerfile: Dockerfile
         username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
With this new action, docker hub releases don't happen when a branch is merged to main/development branches. Instead they happen when there is a new github release/prerelease. This way, new docker images will be made only when we are sure the app is ready for a new release, and each new image will have a suitable semantic version.

Note:
We need to be careful when naming releases/prereleases, since actions rely on regular expressions to trigger.
When we want to create a new release we have to use 'v*.*.*' format, where each * is a positive integer.
When we want to create a new prerelease we have to use 'v*.*.*-name' where each * is a positive integer, '-' is a literal and name can be the name of prerelease. (This is according to https://semver.org/ rule 9)
Examples:
release: 1.0.1
prerelease 1.0.2-alpha